### PR TITLE
Add libgl to environment dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pydantic >=2.11.7
   - click  >=8.2.0
   - vmd
+  - libgl
   - apbs
   - MDAnalysis >=2.9.0
   - jax


### PR DESCRIPTION
vmd depends on liggl, which may not be available in some clusters.